### PR TITLE
change apex to apexcode to match the nvim lsp configs

### DIFF
--- a/common/common.js
+++ b/common/common.js
@@ -1,4 +1,4 @@
-const dialects = { SOQL: "soql", SOSL: "sosl", APEX: "apex" };
+const dialects = { SOQL: "soql", SOSL: "sosl", APEX: "apexcode" };
 
 function createCaseInsensitiveRegex(word) {
   return new RegExp(

--- a/grammar.js
+++ b/grammar.js
@@ -6,7 +6,7 @@ const {
   joined,
 } = require("./common/common.js");
 
-const LANG = "apex";
+const LANG = "apexcode";
 
 // SOSL includes SOQL as a sub-type
 const soslGrammar = require("./common/sosl-grammar.js")(LANG);

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,5 +1,5 @@
 {
-  "name": "apex",
+  "name": "apexcode",
   "word": "identifier",
   "rules": {
     "parser_output": {

--- a/src/parser.c
+++ b/src/parser.c
@@ -92205,7 +92205,7 @@ extern "C" {
 #define extern __declspec(dllexport)
 #endif
 
-extern const TSLanguage *tree_sitter_apex(void) {
+extern const TSLanguage *tree_sitter_apexcode(void) {
   static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,


### PR DESCRIPTION
I couldn't get both tree-sitter and the lsp configs to work in tandem when the parser was set with `apex`. I changed it over to `apexcode` as the filetype and it worked.

I don't know why someone would call it `apexcode` to begin with; that doesn't feel right.